### PR TITLE
fix: ensure cookie names are encoded for js-cookie compatibility

### DIFF
--- a/.changeset/quiet-clocks-open.md
+++ b/.changeset/quiet-clocks-open.md
@@ -1,0 +1,5 @@
+---
+"amplify-adapter-react-router": patch
+---
+
+fix: ensure cookie names are encoded for js-cookie compatibility


### PR DESCRIPTION
When attempting to use this library in our project, we encountered authentication failures on the server side.
Upon investigation, we discovered that the issue was related to cookie name encoding compatibility between client-side and server-side cookie handling.

The problem occurs when AWS Amplify generates cookie names that contain special characters like `@` in the format:  
e.g. `CognitoIdentityServiceProvider.<client_id>.<user_email>.refreshToken=<value>; `

This PR implements the same cookie name encoding strategy used in the official `@aws-amplify/adapter-nextjs` package to ensure compatibility between client-side js-cookie and server-side cookie operations.

See:
- https://github.com/aws-amplify/amplify-js/blob/main/packages/adapter-nextjs/src/utils/cookie/ensureEncodedForJSCookie.ts
- https://github.com/aws-amplify/amplify-js/blob/936c0f79f061a14b239695f3aa2222d4fb9ac028/packages/adapter-nextjs/src/utils/createCookieStorageAdapterFromNextServerContext.ts#L96-L111