### PR TITLE
fix: update amplify.yml to use vp for frontend build after Vite+ migration

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -24,7 +24,7 @@ applications:
         build:
           commands:
             - node -v
-            - vp run pack
+            - vp run -r pack
             - vp run build
       artifacts:
         baseDirectory: .amplify-hosting

--- a/amplify.yml
+++ b/amplify.yml
@@ -20,7 +20,7 @@ applications:
         preBuild:
           commands:
             - curl -fsSL https://viteplus.dev/install.sh | bash
-            - export PATH="$HOME/.local/bin:$PATH"
+            - export PATH="$HOME/.vite-plus/bin:$PATH"
         build:
           commands:
             - node -v

--- a/amplify.yml
+++ b/amplify.yml
@@ -17,10 +17,15 @@ applications:
             - pnpm exec ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
     frontend:
       phases:
+        preBuild:
+          commands:
+            - curl -fsSL https://viteplus.dev/install.sh | bash
+            - export PATH="$HOME/.local/bin:$PATH"
         build:
           commands:
             - node -v
-            - pnpm --workspace-root build
+            - vp run pack
+            - vp run build
       artifacts:
         baseDirectory: .amplify-hosting
         files:

--- a/packages/amplify-adapter-react-router/package.json
+++ b/packages/amplify-adapter-react-router/package.json
@@ -37,8 +37,7 @@
   },
   "scripts": {
     "dev": "vp dev",
-    "pack": "vp pack",
-    "build": "tsc && vp build"
+    "pack": "vp pack"
   },
   "devDependencies": {
     "@aws-amplify/core": "^6.10.5",

--- a/packages/vite-plugin-react-router-amplify-hosting/package.json
+++ b/packages/vite-plugin-react-router-amplify-hosting/package.json
@@ -33,8 +33,7 @@
   },
   "scripts": {
     "dev": "vp dev",
-    "pack": "vp pack",
-    "build": "tsc && vp build"
+    "pack": "vp pack"
   },
   "dependencies": {
     "semver": "^7.7.2"


### PR DESCRIPTION
## Summary

- Fix Amplify Hosting deployment failure caused by missing root `build` script after Vite+ migration
- Add frontend `preBuild` phase to install `vp` via the official installer
- Replace `pnpm --workspace-root build` with `vp run pack` (build workspace packages) and `vp run build` (build frontend app)
- Remove unused `build` script from workspace packages since nothing calls it anymore

## Test plan

- [x] Verify Amplify Hosting deployment succeeds
- [x] Verify `vp run pack` builds each workspace package correctly
- [x] Verify `vp run build` runs `react-router build` in `examples/todo-app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)