### PR TITLE
feat: add nodejs24.x support to ComputeRuntime

### DIFF
--- a/.changeset/add-nodejs24-support.md
+++ b/.changeset/add-nodejs24-support.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-react-router-amplify-hosting": minor
+---
+
+feat: add nodejs24.x support to ComputeRuntime

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -44,6 +44,6 @@
     "vite-tsconfig-paths": "^5.1.4"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/packages/vite-plugin-react-router-amplify-hosting/README.md
+++ b/packages/vite-plugin-react-router-amplify-hosting/README.md
@@ -43,9 +43,9 @@ frontend:
   phases:
     preBuild:
       commands:
-        # vite-plugin-react-router-amplify-hosting requre Node.js v20 or later
-        - nvm install 20
-        - nvm use 20
+        # vite-plugin-react-router-amplify-hosting requires Node.js v20 or later (v20, v22, or v24)
+        - nvm install 24
+        - nvm use 24
         - "npm ci --cache .npm --prefer-offline"
     build:
       commands:
@@ -59,8 +59,8 @@ frontend:
       - ".npm/**/*"
 ```
 
-This plugin require Node.js v20 or later.
-You need to install Node.js v20 or later using nvm in `amplify.yml` or specify 20 for the Node.js version in the Amplify Hosting build image settings as shown below.
+This plugin requires Node.js v20 or later (v20, v22, or v24).
+You need to install Node.js using nvm in `amplify.yml` or specify the Node.js version in the Amplify Hosting build image settings as shown below.
 
 ![the Node.js version in the Amplify Hosting build image settings](./docs/build-settings-node-version.png)
 

--- a/packages/vite-plugin-react-router-amplify-hosting/src/determineRuntimeVersion.test.ts
+++ b/packages/vite-plugin-react-router-amplify-hosting/src/determineRuntimeVersion.test.ts
@@ -9,7 +9,17 @@ import {
 } from "./determineRuntimeVersion";
 
 describe("parseNodeVersion", () => {
-  test("should return nodejs22.x for version >= 22", () => {
+  test("should return nodejs24.x for version >= 24", () => {
+    expect(parseNodeVersion("24")).toBe("nodejs24.x");
+    expect(parseNodeVersion("24.0.0")).toBe("nodejs24.x");
+    expect(parseNodeVersion(">=24.0.0")).toBe("nodejs24.x");
+    expect(parseNodeVersion("^24.0.0")).toBe("nodejs24.x");
+    expect(parseNodeVersion("~24.0.0")).toBe("nodejs24.x");
+    expect(parseNodeVersion("24.x")).toBe("nodejs24.x");
+    expect(parseNodeVersion("25.0.0")).toBe("nodejs24.x");
+  });
+
+  test("should return nodejs22.x for version >= 22 and < 24", () => {
     expect(parseNodeVersion("22")).toBe("nodejs22.x");
     expect(parseNodeVersion("22.0.0")).toBe("nodejs22.x");
     expect(parseNodeVersion(">=22.0.0")).toBe("nodejs22.x");
@@ -98,6 +108,19 @@ describe("determineRuntimeVersion", () => {
     await rm(testDir, { recursive: true, force: true });
   });
 
+  test("should return nodejs24.x when engines.node is >= 24", async () => {
+    await writeFile(
+      path.join(testDir, "package.json"),
+      JSON.stringify({
+        name: "test-app",
+        engines: { node: ">=24.0.0" },
+      }),
+    );
+
+    const result = await determineRuntimeVersion(testDir);
+    expect(result).toBe("nodejs24.x");
+  });
+
   test("should return nodejs22.x when engines.node is >= 22", async () => {
     await writeFile(
       path.join(testDir, "package.json"),
@@ -143,6 +166,10 @@ describe("determineRuntimeVersion", () => {
 
   test("should handle various version formats", async () => {
     const testCases = [
+      { version: "^24.0.0", expected: "nodejs24.x" },
+      { version: "~24.0.0", expected: "nodejs24.x" },
+      { version: "24.x", expected: "nodejs24.x" },
+      { version: "24", expected: "nodejs24.x" },
       { version: "^22.0.0", expected: "nodejs22.x" },
       { version: "~22.0.0", expected: "nodejs22.x" },
       { version: "22.x", expected: "nodejs22.x" },

--- a/packages/vite-plugin-react-router-amplify-hosting/src/determineRuntimeVersion.ts
+++ b/packages/vite-plugin-react-router-amplify-hosting/src/determineRuntimeVersion.ts
@@ -39,6 +39,9 @@ export function parseNodeVersion(nodeVersionSpec?: string): ComputeRuntime {
   const majorVersion = Number.parseInt(match[0], 10);
 
   // Map major version to ComputeRuntime
+  if (majorVersion >= 24) {
+    return "nodejs24.x";
+  }
   if (majorVersion >= 22) {
     return "nodejs22.x";
   }

--- a/packages/vite-plugin-react-router-amplify-hosting/src/generateDeployManifest.ts
+++ b/packages/vite-plugin-react-router-amplify-hosting/src/generateDeployManifest.ts
@@ -1,4 +1,4 @@
-export type ComputeRuntime = "nodejs20.x" | "nodejs22.x";
+export type ComputeRuntime = "nodejs20.x" | "nodejs22.x" | "nodejs24.x";
 
 export function generateDeployManifest({
   reactRouterVersion,

--- a/packages/vite-plugin-react-router-amplify-hosting/src/index.ts
+++ b/packages/vite-plugin-react-router-amplify-hosting/src/index.ts
@@ -75,7 +75,7 @@ export type { PluginOption };
 
 export type PluginOptions = {
   expressVersion?: "5" | "4";
-  computeRuntime?: "nodejs20.x" | "nodejs22.x";
+  computeRuntime?: "nodejs20.x" | "nodejs22.x" | "nodejs24.x";
 };
 export function amplifyHosting(opts?: PluginOptions): Plugin {
   let resolvedConfig: ResolvedConfig;

--- a/packages/vite-plugin-react-router-amplify-hosting/vite.config.ts
+++ b/packages/vite-plugin-react-router-amplify-hosting/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
-import pkg from "./package.json";
+import { defineConfig } from "vite-plus";
+import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
   pack: {


### PR DESCRIPTION
## Summary

- Add `"nodejs24.x"` to `ComputeRuntime` type
- Update `parseNodeVersion` to map Node.js 24+ to `nodejs24.x`
- Add `"nodejs24.x"` to `PluginOptions.computeRuntime` type
- Add test cases for Node.js 24
- Update README `amplify.yml` example and description to reflect v24 support
- Fix `vite.config.ts` to import `defineConfig` from `vite-plus` (resolves `pack` type error and adds required JSON import attribute for Node.js 24)

## Test plan

- [x] `vp test` passes all unit tests
- [x] `parseNodeVersion("24")` returns `"nodejs24.x"`
- [x] `parseNodeVersion("25.0.0")` returns `"nodejs24.x"`
- [x] `parseNodeVersion("23.0.0")` still returns `"nodejs22.x"`