### PR TITLE
feat!: publish ESM-only builds

### DIFF
--- a/.changeset/node22-vite7-support.md
+++ b/.changeset/node22-vite7-support.md
@@ -10,3 +10,4 @@ Breaking changes:
 - Drop support for Node.js 20. Both packages now require Node.js >=22.22.0 (`engines.node`).
 - Drop support for Vite 5 and 6. `vite-plugin-react-router-amplify-hosting` now requires `vite@^7.0.0 || ^8.0.0` as a peer dependency.
 - Remove `nodejs20.x` from the `ComputeRuntime` type and the `computeRuntime` plugin option. When the app's `engines.node` is missing, invalid, or below 22, the deploy manifest now defaults to `nodejs22.x` (previously `nodejs20.x`).
+- Both packages are now ESM-only: the CommonJS build (`dist/*.cjs`) is no longer published. CommonJS consumers on Node.js >=22.22.0 can still load them via `require()` thanks to `require(esm)` support.

--- a/packages/amplify-adapter-react-router/package.json
+++ b/packages/amplify-adapter-react-router/package.json
@@ -20,19 +20,16 @@
     "dist"
   ],
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.mts"
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     },
     "./adapter": {
-      "import": "./dist/adapter.mjs",
-      "require": "./dist/adapter.cjs",
-      "types": "./dist/adapter.d.ts"
+      "types": "./dist/adapter.d.mts",
+      "default": "./dist/adapter.mjs"
     }
   },
   "scripts": {

--- a/packages/amplify-adapter-react-router/vite.config.ts
+++ b/packages/amplify-adapter-react-router/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   pack: {
     unbundle: true,
     dts: true,
-    format: ["esm", "cjs"],
+    format: ["esm"],
     sourcemap: true,
   },
   test: {

--- a/packages/vite-plugin-react-router-amplify-hosting/package.json
+++ b/packages/vite-plugin-react-router-amplify-hosting/package.json
@@ -21,14 +21,12 @@
     "dist"
   ],
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/packages/vite-plugin-react-router-amplify-hosting/vite.config.ts
+++ b/packages/vite-plugin-react-router-amplify-hosting/vite.config.ts
@@ -4,7 +4,7 @@ import pkg from "./package.json" with { type: "json" };
 export default defineConfig({
   pack: {
     dts: true,
-    format: ["esm", "cjs"],
+    format: ["esm"],
     sourcemap: true,
   },
   test: {


### PR DESCRIPTION
## Summary

Follow-up to #322 (Node.js >=22.22.0 / Vite 7+).

- Drop the CommonJS build (`dist/*.cjs`) from both packages: `pack.format` is now `["esm"]`.
- Point `main` to `./dist/index.mjs` and collapse `exports` to `types` + `default` conditions, so CommonJS consumers on Node.js >=22.22.0 can still load the packages via `require(esm)`.
- Fix the `./adapter` export's `types` path, which pointed to a non-existent `dist/adapter.d.ts`; it now points to the emitted `dist/adapter.d.mts`.
- Note the ESM-only change in the existing major changeset.

## Test plan

- [x] `vp run pack` — ESM-only build succeeds, no `.cjs` files in `dist`
- [x] `require()` and `import()` of both packages (including `amplify-adapter-react-router/adapter`) resolve and load on Node.js v24
- [x] `vp run test` — 23/23 tests pass, including integration builds that install the packed tarball against the Vite 7 and Vite 8 templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)