### PR TITLE
chore(renovate): add minimumReleaseAge to avoid pnpm release-age policy failures

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "minimumReleaseAge": "2 days",
   "packageRules": [
     {
       "description": "Integration fixture templates emulate user apps; @react-router/dev's typescript peer range is ^5.1.0 || ^6.0.0, so keep fixtures on typescript 6 until react-router supports 7 (tracked by .github/workflows/check-react-router-ts7.yml)",


### PR DESCRIPTION
## Summary

Renovate PRs #330 and #331 failed CI because `vp install` rejected packages published less than 24 hours ago with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`.

This adds a top-level `minimumReleaseAge: "2 days"` to the Renovate config so Renovate only proposes versions that have been published for at least 2 days, staying clear of the pnpm supply-chain policy cutoff (24 hours) with some margin for rebases.

As a side benefit, this also reduces exposure to supply-chain attacks where malicious package versions are unpublished shortly after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)