### PR TITLE
docs: add Built-in Commands vs Scripts section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ This project is using Vite+, a unified toolchain built on top of Vite, Rolldown,
 
 Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.dev/guide/.
 
+## Built-in Commands vs Scripts
+
+`vp <name>` runs a built-in command. `vp run <name>` runs a `package.json` script or a `vite.config.ts` task. Scripts cannot overwrite built-ins, so `vp dev` and `vp run dev` may do different things. Check `package.json` and `vite.config.ts` first, and run `vp run <name>` when the project defines a script or task with that name.
+
 ## Review Checklist
 
 - [ ] Run `vp install` after pulling remote changes and before getting started.


### PR DESCRIPTION
## Summary
- Add a "Built-in Commands vs Scripts" section to AGENTS.md explaining the difference between `vp <name>` built-in commands and `vp run <name>` for package.json scripts / vite.config.ts tasks
- Brings AGENTS.md in line with the equivalent guidance already present in CLAUDE.md

## Test plan
- [x] Documentation-only change; no code affected