### PR TITLE
fix(ci): rename changesets/action publish input to publish-script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
         id: changesets
         uses: changesets/action@v2.1.0
         with:
-          publish: vp run release
+          publish-script: vp run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `changesets/action@v2` renamed the `publish` input to `publish-script`, which broke the Release workflow (run [31888712236](https://github.com/fossamagna/react-router-amplify/actions/runs/31888712236)).
- Updated `.github/workflows/release.yml` to use the new input name.

## Test plan
- [ ] Merge and confirm the Release workflow runs successfully on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)